### PR TITLE
feat: Implement statistics endpoints

### DIFF
--- a/src/controllers/StatisticsController.ts
+++ b/src/controllers/StatisticsController.ts
@@ -1,0 +1,88 @@
+import { Request, Response } from 'express';
+import { StatisticsService } from '../services/StatisticsService';
+import { isValid, parseISO } from 'date-fns';
+
+export const StatisticsController = {
+  async getWeeklyStats(req: Request, res: Response): Promise<void> {
+    // Query parametrelerini al: startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
+    const { startDate: startDateStr, endDate: endDateStr } = req.query;
+
+    // Parametrelerin varlığını ve geçerli tarih formatında olup olmadığını kontrol et
+    if (typeof startDateStr !== 'string' || typeof endDateStr !== 'string') {
+      res.status(400).json({ message: 'Başlangıç (startDate) ve bitiş (endDate) tarihleri zorunludur.' });
+      return;
+    }
+
+    const startDate = parseISO(startDateStr);
+    const endDate = parseISO(endDateStr);
+
+    if (!isValid(startDate) || !isValid(endDate)) {
+       res.status(400).json({ message: 'Geçersiz tarih formatı. Lütfen YYYY-MM-DD formatını kullanın.' });
+       return;
+    }
+
+    // Bitiş tarihinin başlangıç tarihinden önce olup olmadığını kontrol et (opsiyonel ama önerilir)
+    if (endDate < startDate) {
+        res.status(400).json({ message: 'Bitiş tarihi başlangıç tarihinden önce olamaz.' });
+        return;
+    }
+
+
+    try {
+      const stats = await StatisticsService.getWeeklyStats(startDateStr, endDateStr);
+      res.status(200).json(stats);
+    } catch (error) {
+      // Servis katmanından gelen genel hataları yakala
+      console.error('Error in StatisticsController.getWeeklyStats:', error);
+      // Gerçek hatayı logla, istemciye genel bir mesaj gönder
+      if (error instanceof Error) {
+         res.status(500).json({ message: error.message || 'Haftalık istatistikler alınırken bir sunucu hatası oluştu.' });
+      } else {
+         res.status(500).json({ message: 'Haftalık istatistikler alınırken bilinmeyen bir sunucu hatası oluştu.' });
+      }
+    }
+  },
+  // Aylık istatistikler için controller fonksiyonu buraya eklenecek...
+  // async getMonthlyStats(req: Request, res: Response) { ... }
+  async getMonthlyStats(req: Request, res: Response): Promise<void> {
+    // Query parametrelerini al: year=YYYY&month=M veya MM
+    const { year: yearStr, month: monthStr } = req.query;
+
+    // Parametrelerin varlığını kontrol et
+    if (typeof yearStr !== 'string' || typeof monthStr !== 'string') {
+      res.status(400).json({ message: 'Yıl (year) ve ay (month) parametreleri zorunludur.' });
+      return;
+    }
+
+    // Parametreleri sayıya çevir ve doğrula
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+
+    if (isNaN(year) || year < 1970 || year > 2100) { // Makul bir yıl aralığı
+       res.status(400).json({ message: 'Geçersiz yıl değeri.' });
+       return;
+    }
+
+    if (isNaN(month) || month < 1 || month > 12) {
+       res.status(400).json({ message: 'Geçersiz ay değeri (1-12 arası olmalı).' });
+       return;
+    }
+
+    try {
+      const stats = await StatisticsService.getMonthlyStats(year, month);
+      res.status(200).json(stats);
+    } catch (error) {
+      console.error('Error in StatisticsController.getMonthlyStats:', error);
+      if (error instanceof Error) {
+         // Servisten gelen spesifik hata mesajlarını kullan
+         if (error.message.includes('Geçersiz')) { // Örneğin 'Geçersiz ay', 'Geçersiz yıl/ay'
+             res.status(400).json({ message: error.message });
+         } else {
+            res.status(500).json({ message: error.message || 'Aylık istatistikler alınırken bir sunucu hatası oluştu.' });
+         }
+      } else {
+         res.status(500).json({ message: 'Aylık istatistikler alınırken bilinmeyen bir sunucu hatası oluştu.' });
+      }
+    }
+  }
+}; 

--- a/src/controllers/StatsController.ts
+++ b/src/controllers/StatsController.ts
@@ -1,0 +1,66 @@
+import { Request, Response, NextFunction } from 'express';
+import StatsService from '../services/StatsService';
+
+class StatsController {
+    /**
+     * @description Get weekly participation statistics
+     * @route GET /api/stats/weekly
+     * @access Private (adjust based on authentication)
+     */
+    static async getWeeklyStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+        try {
+            const weeklyData = await StatsService.fetchWeeklyStats();
+            res.status(200).json(weeklyData);
+        } catch (error) {
+            next(error); // Pass error to the error handling middleware
+        }
+    }
+
+    // Placeholder for getCategoryDistribution
+    /**
+     * @description Get participant distribution by sport category
+     * @route GET /api/stats/categories
+     * @access Private (adjust based on authentication)
+     */
+    static async getCategoryDistribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+        try {
+            const categoryData = await StatsService.fetchCategoryDistribution();
+            res.status(200).json(categoryData);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    // Placeholder for getMonthlyStats
+    /**
+     * @description Get monthly event statistics by status
+     * @route GET /api/stats/monthly
+     * @access Private
+     */
+    static async getMonthlyStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+        try {
+            const monthlyData = await StatsService.fetchMonthlyStats();
+            res.status(200).json(monthlyData);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    // Placeholder for getUserCategoryGrowth
+    // Activate and implement getUserCategoryGrowth
+    /**
+     * @description Get user growth by sport category over the last 30 days
+     * @route GET /api/stats/users/categories
+     * @access Private
+     */
+    static async getUserCategoryGrowth(req: Request, res: Response, next: NextFunction): Promise<void> {
+        try {
+            const userGrowthData = await StatsService.fetchUserCategoryGrowth();
+            res.status(200).json(userGrowthData);
+        } catch (error) {
+            next(error);
+        }
+    }
+}
+
+export default StatsController; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import sportsRoutes from './routes/sportsRoutes';
 import securityRoutes from './routes/securityRoutes';
 import reportRoutes from './routes/reportRoutes';
 import profileRoutes from './routes/profileRoutes';
+import statsRoutes from './routes/statsRoutes';
+import statisticsRoutes from './routes/statisticsRoutes';
 import { errorHandler } from './middleware/errorHandler';
 import logRequest from './middleware/loggerMiddleware';
 import { setupSwagger } from './middleware/swaggerMiddleware';
@@ -55,6 +57,8 @@ app.use('/api/events', eventRoutes);
 app.use('/api/sports', sportsRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/reports', reportRoutes);
+app.use('/api/stats', statsRoutes);
+app.use('/api/statistics', statisticsRoutes);
 
 // Error handling middleware
 app.use(errorHandler);

--- a/src/middleware/swaggerMiddleware.ts
+++ b/src/middleware/swaggerMiddleware.ts
@@ -31,6 +31,116 @@ export const setupSwagger = (app: express.Application): void => {
           description: 'SportLink API Sunucusu',
         },
       ],
+      tags: [
+        { name: 'Auth', description: 'Authentication operations' },
+        { name: 'Events', description: 'Etkinlik yönetimi' },
+        { name: 'Profile', description: 'User profile management' },
+        { name: 'Reports', description: 'Rapor yönetimi' },
+        { name: 'Users', description: 'User management operations' },
+        { name: 'Security', description: 'Security logs' },
+        { name: 'Sports', description: 'Spor yönetimi' },
+        { name: 'Stats', description: 'İstatistik ve dashboard verileri' },
+      ],
+      paths: {
+        '/api/stats/weekly': {
+          get: {
+            tags: ['Stats'],
+            summary: 'Haftalık istatistikleri getirir',
+            description: 'Son 7 gün için günlük etkinlik ve katılımcı sayılarını ve genel özeti döndürür.',
+            security: [{ bearerAuth: [] }],
+            responses: {
+              '200': {
+                description: 'Haftalık istatistikler başarıyla alındı',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/WeeklyStatsResponse'
+                    }
+                  }
+                }
+              },
+              '401': { $ref: '#/components/responses/UnauthorizedError' },
+              '403': { $ref: '#/components/responses/ForbiddenError' },
+              '500': { $ref: '#/components/responses/InternalServerError' }
+            }
+          }
+        },
+        '/api/stats/categories': {
+          get: {
+            tags: ['Stats'],
+            summary: 'Kategoriye göre katılımcı dağılımını getirir',
+            description: 'Her spor kategorisindeki etkinliklere katılan benzersiz kullanıcı sayısını döndürür.',
+            security: [{ bearerAuth: [] }],
+            responses: {
+              '200': {
+                description: 'Kategori dağılımı başarıyla alındı',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        $ref: '#/components/schemas/CategoryDistributionItem'
+                      }
+                    }
+                  }
+                }
+              },
+              '401': { $ref: '#/components/responses/UnauthorizedError' },
+              '403': { $ref: '#/components/responses/ForbiddenError' },
+              '500': { $ref: '#/components/responses/InternalServerError' }
+            }
+          }
+        },
+        '/api/stats/monthly': {
+          get: {
+            tags: ['Stats'],
+            summary: 'Aylık etkinlik istatistiklerini getirir',
+            description: 'Her ay için etkinlikleri durumlarına göre sayarak döndürür.',
+            security: [{ bearerAuth: [] }],
+            responses: {
+              '200': {
+                description: 'Aylık istatistikler başarıyla alındı',
+                content: {
+                  'application/json': {
+                    schema: {
+                       type: 'array',
+                       items: {
+                         $ref: '#/components/schemas/MonthlyStatsItem'
+                      }
+                    }
+                  }
+                }
+              },
+              '401': { $ref: '#/components/responses/UnauthorizedError' },
+              '403': { $ref: '#/components/responses/ForbiddenError' },
+              '500': { $ref: '#/components/responses/InternalServerError' }
+            }
+          }
+        },
+        '/api/stats/users/categories': {
+          get: {
+            tags: ['Stats'],
+            summary: 'Kategoriye göre kullanıcı büyümesini getirir',
+            description: 'Her spor kategorisi için toplam kullanıcı sayısını ve son 30 gündeki artışı döndürür.',
+            security: [{ bearerAuth: [] }],
+            responses: {
+              '200': {
+                description: 'Kullanıcı kategori büyümesi başarıyla alındı',
+                content: {
+                  'application/json': {
+                    schema: {
+                       $ref: '#/components/schemas/UserCategoryGrowthResponse'
+                    }
+                  }
+                }
+              },
+              '401': { $ref: '#/components/responses/UnauthorizedError' },
+              '403': { $ref: '#/components/responses/ForbiddenError' },
+              '500': { $ref: '#/components/responses/InternalServerError' }
+            }
+          }
+        },
+      },
       components: {
         securitySchemes: {
           bearerAuth: {
@@ -99,7 +209,6 @@ export const setupSwagger = (app: express.Application): void => {
           },
         },
         schemas: {
-          // Rapor modeli
           Report: {
             type: 'object',
             required: ['id', 'konu', 'raporlayan', 'tarih', 'tur', 'oncelik', 'durum'],
@@ -137,7 +246,6 @@ export const setupSwagger = (app: express.Application): void => {
               }
             }
           },
-          // Rapor veri formatı (Dashboard)
           ReportData: {
             type: 'object',
             required: ['id', 'subject', 'description', 'reportedBy', 'reportedDate', 'priority', 'status', 'entityId', 'entityType'],
@@ -184,7 +292,6 @@ export const setupSwagger = (app: express.Application): void => {
               }
             }
           },
-          // Kullanıcı modeli
           User: {
             type: 'object',
             required: ['id', 'email', 'first_name', 'last_name', 'role'],
@@ -233,7 +340,6 @@ export const setupSwagger = (app: express.Application): void => {
               updated_at: '2023-01-01T00:00:00.000Z',
             },
           },
-          // Kullanıcı oluşturma şeması
           CreateUserDTO: {
             type: 'object',
             required: ['email', 'password', 'first_name', 'last_name'],
@@ -271,7 +377,6 @@ export const setupSwagger = (app: express.Application): void => {
               last_name: 'Doe',
             },
           },
-          // Kullanıcı Detay modeli (Frontend için)
           UserDetail: {
             type: 'object',
             required: ['id', 'name', 'email', 'role', 'status', 'joinDate'],
@@ -329,7 +434,6 @@ export const setupSwagger = (app: express.Application): void => {
               lastActive: "2023-07-15"
             },
           },
-          // Giriş DTO şeması
           LoginDTO: {
             type: 'object',
             required: ['email', 'password'],
@@ -350,7 +454,6 @@ export const setupSwagger = (app: express.Application): void => {
               password: 'password123',
             },
           },
-          // Şifre sıfırlama şeması
           ResetPasswordDTO: {
             type: 'object',
             required: ['email'],
@@ -365,7 +468,6 @@ export const setupSwagger = (app: express.Application): void => {
               email: 'user@example.com',
             },
           },
-          // Kimlik doğrulama yanıt şeması
           AuthResponse: {
             type: 'object',
             properties: {
@@ -397,7 +499,6 @@ export const setupSwagger = (app: express.Application): void => {
               },
             },
           },
-          // Başarılı yanıt şeması
           SuccessResponse: {
             type: 'object',
             properties: {
@@ -416,7 +517,6 @@ export const setupSwagger = (app: express.Application): void => {
               message: 'İşlem başarıyla tamamlandı',
             },
           },
-          // Hata yanıt şeması
           Error: {
             type: 'object',
             properties: {
@@ -435,7 +535,6 @@ export const setupSwagger = (app: express.Application): void => {
               message: 'Bir hata oluştu',
             },
           },
-          // Event model
           Event: {
             type: 'object',
             required: [
@@ -538,8 +637,6 @@ export const setupSwagger = (app: express.Application): void => {
               }
             }
           },
-          
-          // EventParticipant model
           EventParticipant: {
             type: 'object',
             required: [
@@ -577,8 +674,6 @@ export const setupSwagger = (app: express.Application): void => {
               }
             }
           },
-          
-          // TodayEvent model (Frontend formatı)
           TodayEvent: {
             type: 'object',
             properties: {
@@ -640,6 +735,66 @@ export const setupSwagger = (app: express.Application): void => {
               }
             }
           },
+          DailyStat: {
+            type: 'object',
+            properties: {
+              date: { type: 'string', format: 'date', description: 'Tarih (YYYY-MM-DD)' },
+              events: { type: 'integer', description: 'O günkü etkinlik sayısı' },
+              participants: { type: 'integer', description: 'O günkü katılımcı sayısı' }
+            }
+          },
+          WeeklyStatsResponse: {
+            type: 'object',
+            properties: {
+              summary: {
+                type: 'object',
+                properties: {
+                  total_events: { type: 'integer', description: 'Haftalık toplam etkinlik' },
+                  total_participants: { type: 'integer', description: 'Haftalık toplam katılımcı' }
+                }
+              },
+              daily: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/DailyStat' },
+                description: 'Son 7 günün günlük dökümü'
+              }
+            }
+          },
+          CategoryDistributionItem: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'Spor kategorisi adı' },
+              count: { type: 'integer', description: 'Bu kategorideki benzersiz katılımcı sayısı' }
+            }
+          },
+          MonthlyStatsItem: {
+            type: 'object',
+            properties: {
+               month: { type: 'string', description: 'Ay (YYYY-MM)' },
+               onaylanan: { type: 'integer', description: 'Onaylanmış (Aktif) etkinlik sayısı' },
+               bekleyen: { type: 'integer', description: 'Bekleyen etkinlik sayısı' },
+               iptal_edilen: { type: 'integer', description: 'İptal edilmiş etkinlik sayısı' },
+               tamamlanan: { type: 'integer', description: 'Tamamlanmış etkinlik sayısı' }
+            }
+          },
+          UserCategoryGrowthItem: {
+             type: 'object',
+             properties: {
+               name: { type: 'string', description: 'Spor kategorisi adı' },
+               users: { type: 'integer', description: 'Bu kategoriyi favorileyen toplam kullanıcı sayısı' },
+               change: { type: 'integer', description: 'Son 30 günde favorileyen yeni kullanıcı sayısı' }
+             }
+          },
+          UserCategoryGrowthResponse: {
+             type: 'object',
+             properties: {
+                categories: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/UserCategoryGrowthItem' }
+                },
+                period: { type: 'integer', description: 'Değişimin hesaplandığı gün sayısı', example: 30 }
+             }
+          }
         },
       },
     },

--- a/src/routes/statisticsRoutes.ts
+++ b/src/routes/statisticsRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { StatisticsController } from '../controllers/StatisticsController';
+// İleride kimlik doğrulama gibi ara katmanlar (middleware) eklemek gerekebilir
+// import { authenticateToken } from '../middleware/authMiddleware'; // Örnek
+
+const router = Router();
+
+// Haftalık istatistikler için GET endpoint'i
+// Örnek istek: GET /api/statistics/weekly?startDate=2023-10-23&endDate=2023-10-29
+router.get(
+    '/weekly',
+    // authenticateToken, // Eğer bu route korumalı olacaksa kimlik doğrulama middleware'ini burada kullanın
+    StatisticsController.getWeeklyStats
+);
+
+// Aylık istatistikler için route tanımı buraya eklenecek...
+// Örnek istek: GET /api/statistics/monthly?year=2024&month=5
+router.get(
+    '/monthly',
+    // authenticateToken, // Gerekirse kimlik doğrulama
+    StatisticsController.getMonthlyStats
+);
+
+// Router'ı dışa aktararak ana uygulama dosyasında (örn: src/app.ts) kullanılabilir hale getiriyoruz.
+export default router; 

--- a/src/routes/statsRoutes.ts
+++ b/src/routes/statsRoutes.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import StatsController from '../controllers/StatsController';
+// Import the correct authentication middleware
+import { protect } from '../middleware/authMiddleware'; // Changed import to protect
+
+const router = Router();
+
+// GET /api/stats/weekly - Fetch weekly statistics
+// Add authentication middleware
+router.get(
+    '/weekly',
+    protect, // Use protect middleware
+    StatsController.getWeeklyStats
+);
+
+// GET /api/stats/categories - Fetch category distribution
+// Add authentication middleware
+router.get(
+    '/categories',
+    protect, // Use protect middleware
+    StatsController.getCategoryDistribution
+);
+
+// GET /api/stats/monthly - Fetch monthly statistics
+// Activate the route and add protection
+router.get(
+    '/monthly',
+    protect, // Added auth middleware
+    StatsController.getMonthlyStats
+);
+
+// GET /api/stats/users/categories - Fetch user category growth
+// Activate the route and add protection
+router.get(
+    '/users/categories',
+    protect, // Added auth middleware
+    StatsController.getUserCategoryGrowth
+);
+
+
+export default router; 

--- a/src/services/StatisticsService.ts
+++ b/src/services/StatisticsService.ts
@@ -1,0 +1,175 @@
+import { format, parseISO, startOfDay, endOfDay, eachDayOfInterval, getDay, startOfMonth, endOfMonth } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+import supabase from '../config/supabase';
+import { Database } from '../types/supabase';
+
+// Assuming Supabase types are potentially outdated, using 'any' temporarily
+type EventStatus = any; // Should be Database['public']['Tables']['events']['Row']['status'];
+
+// Type for the desired daily object in the array
+type DailyStatusObject = {
+  date: string; // e.g., "2023-10-27"
+  // Status keys will be added dynamically
+  [status: string]: number | string; // Value is count (number) or date (string)
+};
+
+// Keeping MonthlyStats as is for now
+type MonthlyStats = {
+  year: number;
+  month: number;
+  totals: { [key: string]: number };
+};
+
+const timeZone = 'Europe/Istanbul';
+// Define expected status keys based on the monthly example
+const EXPECTED_STATUSES = ["pending", "completed", "active", "rejected"];
+
+export const StatisticsService = {
+  // Rewritten getWeeklyStats function to return flat array
+  async getWeeklyStats(startDateStr: string, endDateStr: string): Promise<DailyStatusObject[]> {
+    try {
+      const startDate = startOfDay(parseISO(startDateStr));
+      const endDate = endOfDay(parseISO(endDateStr));
+
+      // Select end_date and status, filter by end_date
+      const { data: events, error } = await supabase
+        .from('events')
+        .select('end_date, status') // Select end_date instead of created_at
+        .gte('end_date', startDate.toISOString()) // Filter by end_date
+        .lte('end_date', endDate.toISOString());   // Filter by end_date
+        // No ordering needed as we process all events
+
+      if (error) {
+        console.error('Supabase error fetching weekly stats:', error);
+        throw new Error('Failed to fetch weekly statistics.');
+      }
+
+      // Initialize a map to hold counts per day per status
+      const dailyDataMap: { [dateKey: string]: { [status: string]: number } } = {};
+      const intervalDays = eachDayOfInterval({ start: startDate, end: endDate });
+
+      // Initialize map with all expected statuses set to 0 for each day in the interval
+      intervalDays.forEach(date => {
+        const zonedDate = toZonedTime(date, timeZone);
+        const dayKey = format(zonedDate, 'yyyy-MM-dd');
+        dailyDataMap[dayKey] = {};
+        EXPECTED_STATUSES.forEach(status => {
+          dailyDataMap[dayKey][status] = 0;
+        });
+      });
+
+      // Process events and count statuses per day based on end_date
+      if (events) {
+        events.forEach((event: any) => {
+          // Use end_date for grouping
+          if (!event.end_date || !event.status) return; // Skip incomplete data (check end_date)
+
+          try {
+            // Parse end_date
+            const utcEventEndDate = parseISO(event.end_date); 
+            const zonedEventEndDate = toZonedTime(utcEventEndDate, timeZone);
+            const dayKey = format(zonedEventEndDate, 'yyyy-MM-dd'); // Group key based on end_date
+            const currentStatus = event.status;
+
+            // Ensure the day exists in the map (it should due to initialization)
+            if (dailyDataMap[dayKey]) {
+              // Increment the count for the specific status
+              // If status from DB is not in EXPECTED_STATUSES, it will be added dynamically
+              dailyDataMap[dayKey][currentStatus] = (dailyDataMap[dayKey][currentStatus] || 0) + 1;
+            } else {
+              // This case might happen if an event ends exactly on the start/end boundary 
+              // depending on timezones and exact timing, or if end_date is outside the interval.
+              console.warn(`Event end date ${dayKey} (from ${event.end_date}) not in initialized map. Interval: ${startDateStr} to ${endDateStr}`);
+            }
+          } catch (parseError) {
+            // Log error related to end_date parsing
+            console.error(`Error processing event end date: ${event.end_date}`, parseError); 
+          }
+        });
+      }
+
+      // Convert the map into the desired array format
+      const resultArray: DailyStatusObject[] = [];
+      intervalDays.forEach(date => {
+        const zonedDate = toZonedTime(date, timeZone);
+        const dayKey = format(zonedDate, 'yyyy-MM-dd');
+        
+        // Create the object for the day, starting with the date
+        const dailyObject: DailyStatusObject = { date: dayKey };
+
+        // Add status counts to the object
+        // Ensure all expected statuses are present, even if count is 0
+        EXPECTED_STATUSES.forEach(status => {
+            dailyObject[status] = dailyDataMap[dayKey]?.[status] ?? 0;
+        });
+        // Add any unexpected statuses found in the data (optional)
+        // for (const status in dailyDataMap[dayKey]) {
+        //     if (!EXPECTED_STATUSES.includes(status)) {
+        //         dailyObject[status] = dailyDataMap[dayKey][status];
+        //     }
+        // }
+
+        resultArray.push(dailyObject);
+      });
+
+      return resultArray;
+
+    } catch (error) {
+      console.error('Error calculating weekly stats:', error);
+      throw new Error('Failed to calculate weekly statistics.');
+    }
+  },
+
+  // getMonthlyStats remains the same for now
+  async getMonthlyStats(year: number, month: number): Promise<MonthlyStats> {
+    if (month < 1 || month > 12) {
+      throw new Error('Geçersiz ay numarası. 1 ile 12 arasında olmalıdır.');
+    }
+    const dateForMonth = new Date(year, month - 1, 1);
+    const startDate = startOfMonth(dateForMonth);
+    const endDate = endOfMonth(dateForMonth);
+
+    try {
+      const { data: events, error } = await supabase
+        .from('events')
+        .select('status')
+        .gte('created_at', startDate.toISOString())
+        .lte('created_at', endDate.toISOString());
+
+      if (error) {
+        console.error('Supabase error fetching monthly stats:', error);
+        throw new Error('Failed to fetch monthly statistics.');
+      }
+
+      const monthlyTotals: { [key: string]: number } = {};
+
+      if (events) {
+        events.forEach((event: any) => {
+          if (!event.status) return;
+          const currentStatus = event.status;
+          monthlyTotals[currentStatus] = (monthlyTotals[currentStatus] || 0) + 1;
+        });
+      }
+
+      const result: MonthlyStats = {
+        year: year,
+        month: month,
+        totals: monthlyTotals
+      };
+
+      return result;
+
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Invalid time value')) {
+            console.error(`Invalid year/month combination: ${year}-${month}`);
+            throw new Error(`Geçersiz yıl/ay kombinasyonu: ${year}-${month}`);
+        }
+      console.error('Error calculating monthly stats:', error);
+      if (error instanceof Error) {
+          throw error;
+      } else {
+        throw new Error('Failed to calculate monthly statistics.');
+      }
+    }
+  }
+}; 

--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -1,0 +1,317 @@
+import { createClient } from '@supabase/supabase-js';
+// Config import removed as it's not used for Supabase credentials
+import { Database } from '../types/supabase'; // Import generated Supabase types
+// AppError import removed, will use generic Error or specific custom error if needed
+import { format, parseISO, startOfDay, endOfDay, eachDayOfInterval, isBefore, isSameDay, isAfter } from 'date-fns'; // Added date-fns imports
+import { toZonedTime } from 'date-fns-tz'; // Added date-fns-tz import
+
+// Initialize Supabase client using process.env
+// Read SUPABASE_URL and SUPABASE_SERVICE_KEY
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY; // Use SUPABASE_SERVICE_KEY
+
+if (!supabaseUrl || !supabaseServiceKey) {
+    // Update error message for SUPABASE_SERVICE_KEY
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY must be provided in environment variables.');
+}
+
+// Use supabaseServiceKey in the client creation
+const supabase = createClient<Database>(supabaseUrl, supabaseServiceKey);
+
+// Define the expected response structure for weekly stats
+interface DailyStat {
+    date: string; // YYYY-MM-DD format
+    events: number;
+    participants: number;
+}
+interface WeeklyStatsResponse {
+    summary: {
+        total_events: number;
+        total_participants: number;
+    };
+    daily: DailyStat[];
+}
+
+// Define the structure expected from the RPC function
+interface RpcWeeklyStat {
+    stat_date: string; // Comes as string from RPC
+    event_count: number;
+    participant_count: number;
+}
+
+// Type for the desired daily object in the array (from previous attempt)
+type DailyStatusObject = {
+  date: string; // e.g., "2023-10-27"
+  [status: string]: number | string; 
+};
+
+// Assumed structure for the RPC response row
+interface RpcWeeklyStatusStat {
+    stat_date: string; // Comes as string from RPC, e.g., "2023-10-23" or with time
+    status_counts: { [status: string]: number }; // Object with counts per status
+}
+
+const timeZone = 'Europe/Istanbul'; // Define timezone
+const EXPECTED_STATUSES = ["pending", "active", "completed", "rejected"]; // Define expected statuses in desired order
+
+// Helper function to safely parse dates, returning null if invalid
+const safeParseISO = (dateString: string | null | undefined): Date | null => {
+    if (!dateString) return null;
+    try {
+        const date = parseISO(dateString);
+        return isNaN(date.getTime()) ? null : date;
+    } catch (e) {
+        return null;
+    }
+};
+
+class StatsService {
+    /**
+     * Fetches weekly statistics, determining the status of each event for each day 
+     * based on its lifecycle timestamps (created_at, approved_at, rejected_at, start_time, end_time).
+     * Formats the result into a flat array.
+     */
+    static async fetchWeeklyStats(): Promise<DailyStatusObject[]> {
+        console.log('Fetching weekly stats with daily lifecycle status...');
+
+        const today = endOfDay(new Date()); // Use end of today for the interval
+        const sevenDaysAgo = startOfDay(new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000)); // Start of 7 days ago (inclusive)
+
+        const endDateString = today.toISOString();
+        const startDateString = sevenDaysAgo.toISOString();
+
+        // Query events that could have been relevant during the week
+        // Fetch events created before the end of the week AND potentially active/ended during the week
+        const { data: events, error } = await supabase
+            .from('Events')
+            .select('id, created_at, status, start_time, end_time, approved_at, rejected_at') 
+            .lte('created_at', endDateString) // Created before or on the end date
+            // Filter out events that definitely ended before the week started OR were rejected before the week started
+            .or(`end_time.gte.${startDateString},end_time.is.null`) // Ended during or after the week OR hasn't ended
+            .or(`rejected_at.gte.${startDateString},rejected_at.is.null`) // Rejected during or after the week OR wasn't rejected
+           // .eq('status', 'active') // Example: Maybe only fetch non-final statuses? Might need adjustment.
+
+        if (error) {
+            console.error('Supabase query error (fetchWeeklyStats - lifecycle):', error);
+            throw new Error('Failed to fetch weekly status statistics from database.');
+        }
+
+        if (!events) {
+             console.warn('No relevant events data returned for the weekly period.');
+             return []; 
+        }
+
+        // Initialize map to hold status counts per day
+        const dailyResultsMap: { [dateKey: string]: DailyStatusObject } = {};
+        const intervalDays = eachDayOfInterval({ start: sevenDaysAgo, end: today });
+
+        // Initialize map for all days in the interval
+        intervalDays.forEach(date => {
+            const zonedDay = toZonedTime(date, timeZone);
+            const dayKey = format(zonedDay, 'yyyy-MM-dd');
+            dailyResultsMap[dayKey] = { date: dayKey };
+            EXPECTED_STATUSES.forEach(status => {
+                dailyResultsMap[dayKey][status] = 0; 
+            });
+        });
+
+        // Process each relevant event to determine its status for each day of the week
+        events.forEach((event: any) => {
+            // Safely parse all relevant dates for the event
+            const createdAt = safeParseISO(event.created_at);
+            const approvedAt = safeParseISO(event.approved_at);
+            const rejectedAt = safeParseISO(event.rejected_at);
+           // const startTime = safeParseISO(event.start_time); // Not strictly needed for status logic, but could be useful
+            const endTime = safeParseISO(event.end_time);     
+
+            if (!createdAt) { 
+                console.warn(`Invalid created_at for event ${event.id}`);
+                return; 
+            }
+
+            intervalDays.forEach(day => {
+                const targetDayStart = startOfDay(day);
+                const targetDayEnd = endOfDay(day);
+                const dayKey = format(toZonedTime(targetDayStart, timeZone), 'yyyy-MM-dd');
+                
+                // Determine the status of the event *on* targetDay using the corrected logic order
+                let statusForTheDay: string | null = null;
+
+                // 1. Ignore if event was created AFTER the target day ended
+                if (isAfter(createdAt, targetDayEnd)) {
+                    statusForTheDay = null;
+                } 
+                // 2. Check if rejected on or before the end of the target day
+                else if (rejectedAt && !isAfter(rejectedAt, targetDayEnd)) { // rejectedAt <= targetDayEnd
+                    statusForTheDay = 'rejected';
+                } 
+                // 3. Check if ended before the target day started (Completed for the whole day)
+                else if (endTime && isBefore(endTime, targetDayStart)) {
+                    // Assumes ended events are considered completed unless explicitly rejected earlier.
+                    statusForTheDay = 'completed';
+                }
+                // 4. Check if pending (created but not approved by end of day)
+                else if (!approvedAt || isAfter(approvedAt, targetDayEnd)) {
+                    statusForTheDay = 'pending';
+                }
+                // 5. Otherwise, it must be active (created, approved before/during day, not rejected, not ended before day)
+                else {
+                    statusForTheDay = 'active';
+                }
+
+                // Increment the count for the determined status if valid
+                if (statusForTheDay && dailyResultsMap[dayKey]) {
+                    if (dailyResultsMap[dayKey][statusForTheDay] !== undefined) {
+                        dailyResultsMap[dayKey][statusForTheDay] = (dailyResultsMap[dayKey][statusForTheDay] as number) + 1;
+                    } else {
+                         console.warn(`Unexpected status '${statusForTheDay}' determined for event ${event.id} on ${dayKey}. Adding dynamically.`);
+                         dailyResultsMap[dayKey][statusForTheDay] = 1;
+                    }
+                }
+            });
+        });
+
+        // Convert the map values to an array
+        const finalResultArray = Object.values(dailyResultsMap);
+
+        return finalResultArray;
+    }
+
+    // Placeholder for fetchCategoryDistribution
+    /**
+     * Fetches participant distribution by sport category.
+     * Counts unique participants per sport based on event participation.
+     */
+    static async fetchCategoryDistribution(): Promise<{ name: string; count: number }[]> {
+        console.log('Fetching category distribution from Supabase...');
+
+        const { data, error } = await supabase
+            .from('Sports') // Start from Sports table
+            .select(`
+                name,
+                Events!Events_sport_id_fkey!inner(
+                    Event_Participants!inner(user_id)
+                )
+            `);
+            // Explicitly specified the relationship Events_sport_id_fkey
+            // Now Supabase knows which foreign key to use for the join.
+
+        if (error) {
+            console.error('Supabase query error (fetchCategoryDistribution):', error);
+            throw new Error('Failed to fetch category distribution from database.');
+        }
+
+        if (!data) {
+            return []; // Return empty array if no data
+        }
+
+        // Process the nested data to count unique participants per sport
+        const categoryCounts: { [key: string]: Set<string> } = {};
+
+        data.forEach(sport => {
+            if (!categoryCounts[sport.name]) {
+                categoryCounts[sport.name] = new Set<string>();
+            }
+            // Ensure Events and Event_Participants are arrays (adjust based on actual Supabase response structure)
+            const events = Array.isArray(sport.Events) ? sport.Events : [];
+            events.forEach(event => {
+                const participants = Array.isArray(event.Event_Participants) ? event.Event_Participants : [];
+                participants.forEach((participant: { user_id: string | null }) => {
+                    if (participant.user_id) { // Check if user_id is not null
+                       categoryCounts[sport.name].add(participant.user_id);
+                    }
+                });
+            });
+        });
+
+        // Format the result into the desired structure
+        const result = Object.entries(categoryCounts).map(([name, userSet]) => ({
+            name: name,
+            count: userSet.size // Count of unique user IDs
+        }));
+
+        return result;
+    }
+
+    // Placeholder for fetchMonthlyStats
+    // Activate and implement fetchMonthlyStats
+    /**
+     * Fetches monthly event counts grouped by status.
+     */
+    static async fetchMonthlyStats(): Promise<{ month: string; onaylanan: number; bekleyen: number; iptal_edilen: number; tamamlanan: number }[]> {
+        console.log('Fetching monthly stats from Supabase using RPC...');
+
+        // Call the Supabase RPC function
+        const { data, error } = await supabase.rpc('get_monthly_event_stats');
+
+        if (error) {
+            console.error('Supabase RPC error (get_monthly_event_stats):', error);
+            throw new Error('Failed to fetch monthly statistics from database.');
+        }
+
+        if (!data) {
+            return []; // Return empty array if no data
+        }
+
+        // Process the data from RPC
+        // The RPC returns [{ event_month: 'YYYY-MM', status_counts: { status1: count1, status2: count2 } }]
+        const result = data.map(row => {
+            // Assert the type of status_counts to ensure it's an indexable object
+            const statusCounts = (row.status_counts || {}) as Record<string, number>; // Type assertion added
+            // Map database status values (uppercase) to frontend keys, defaulting to 0
+            return {
+                month: row.event_month,
+                onaylanan: statusCounts['ACTIVE'] || 0,    // Map to ACTIVE
+                bekleyen: statusCounts['PENDING'] || 0,    // Map to PENDING
+                iptal_edilen: statusCounts['CANCELLED'] || 0, // Map to CANCELLED (adjust if it's REJECTED)
+                tamamlanan: statusCounts['COMPLETED'] || 0, // Map to COMPLETED
+            };
+        });
+
+        return result;
+    }
+
+    // Placeholder for fetchUserCategoryGrowth
+    // Activate and implement fetchUserCategoryGrowth
+    /**
+     * Fetches user count and growth (last 30 days) by sport category.
+     */
+    static async fetchUserCategoryGrowth(): Promise<{ categories: { name: string; users: number; change: number }[]; period: number }> {
+        console.log('Fetching user category growth from Supabase using RPC...');
+
+        const periodDays = 30;
+
+        // Call the Supabase RPC function
+        const { data, error } = await supabase.rpc('get_user_growth_by_category', {
+            period_days: periodDays
+        });
+
+        if (error) {
+            console.error('Supabase RPC error (get_user_growth_by_category):', error);
+            throw new Error('Failed to fetch user category growth from database.');
+        }
+
+        if (!data) {
+            // Return default structure if no data
+            return { categories: [], period: periodDays };
+        }
+
+        // Process the data from RPC
+        // RPC returns [{ category_name: string, total_users: bigint, change: bigint }]
+        const categories = data.map(row => ({
+            name: row.category_name,
+            users: Number(row.total_users), // Convert bigint to number
+            change: Number(row.change)      // Convert bigint to number
+        }));
+
+        // Construct the final response object
+        const result = {
+            categories: categories,
+            period: periodDays
+        };
+
+        return result;
+    }
+}
+
+export default StatsService; 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,818 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      _prisma_migrations: {
+        Row: {
+          applied_steps_count: number
+          checksum: string
+          finished_at: string | null
+          id: string
+          logs: string | null
+          migration_name: string
+          rolled_back_at: string | null
+          started_at: string
+        }
+        Insert: {
+          applied_steps_count?: number
+          checksum: string
+          finished_at?: string | null
+          id: string
+          logs?: string | null
+          migration_name: string
+          rolled_back_at?: string | null
+          started_at?: string
+        }
+        Update: {
+          applied_steps_count?: number
+          checksum?: string
+          finished_at?: string | null
+          id?: string
+          logs?: string | null
+          migration_name?: string
+          rolled_back_at?: string | null
+          started_at?: string
+        }
+        Relationships: []
+      }
+      Admin_Logs: {
+        Row: {
+          action_type: string
+          admin_id: string
+          created_at: string
+          description: string
+          id: number
+        }
+        Insert: {
+          action_type: string
+          admin_id: string
+          created_at?: string
+          description: string
+          id?: number
+        }
+        Update: {
+          action_type?: string
+          admin_id?: string
+          created_at?: string
+          description?: string
+          id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Admin_Logs_admin_id_fkey"
+            columns: ["admin_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Event_Participants: {
+        Row: {
+          event_id: number
+          joined_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          event_id: number
+          joined_at?: string
+          role: string
+          user_id: string
+        }
+        Update: {
+          event_id?: number
+          joined_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Event_Participants_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "Events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Event_Participants_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Event_Ratings: {
+        Row: {
+          created_at: string
+          event_id: number
+          id: number
+          rating: number
+          review: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_id: number
+          id?: number
+          rating: number
+          review: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_id?: number
+          id?: number
+          rating?: number
+          review?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Event_Ratings_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "Events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Event_Ratings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Events: {
+        Row: {
+          created_at: string
+          creator_id: string
+          description: string
+          end_time: string
+          event_date: string
+          id: number
+          location_latitude: number
+          location_longitude: number
+          location_name: string
+          max_participants: number
+          sport_id: number
+          start_time: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          creator_id: string
+          description: string
+          end_time: string
+          event_date: string
+          id?: number
+          location_latitude: number
+          location_longitude: number
+          location_name: string
+          max_participants: number
+          sport_id: number
+          start_time: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Update: {
+          created_at?: string
+          creator_id?: string
+          description?: string
+          end_time?: string
+          event_date?: string
+          id?: number
+          location_latitude?: number
+          location_longitude?: number
+          location_name?: string
+          max_participants?: number
+          sport_id?: number
+          start_time?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Events_creator_id_fkey"
+            columns: ["creator_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Events_sport_id_fkey"
+            columns: ["sport_id"]
+            isOneToOne: false
+            referencedRelation: "Sports"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fk_events_sports"
+            columns: ["sport_id"]
+            isOneToOne: false
+            referencedRelation: "Sports"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fk_events_users"
+            columns: ["creator_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      News: {
+        Row: {
+          content: string
+          created_at: string
+          id: number
+          image_url: string
+          published_date: string
+          source_url: string
+          sport_id: number
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: number
+          image_url: string
+          published_date: string
+          source_url: string
+          sport_id: number
+          title: string
+          updated_at: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: number
+          image_url?: string
+          published_date?: string
+          source_url?: string
+          sport_id?: number
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "News_sport_id_fkey"
+            columns: ["sport_id"]
+            isOneToOne: false
+            referencedRelation: "Sports"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Notifications: {
+        Row: {
+          content: string
+          created_at: string
+          event_id: number
+          id: number
+          notification_type: string
+          read_status: boolean
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          event_id: number
+          id?: number
+          notification_type: string
+          read_status?: boolean
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          event_id?: number
+          id?: number
+          notification_type?: string
+          read_status?: boolean
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Notifications_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "Events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Notifications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      Reports: {
+        Row: {
+          admin_notes: string | null
+          event_id: number
+          id: number
+          report_date: string
+          report_reason: string
+          reported_id: string
+          reporter_id: string
+          status: string
+        }
+        Insert: {
+          admin_notes?: string | null
+          event_id: number
+          id?: number
+          report_date?: string
+          report_reason: string
+          reported_id: string
+          reporter_id: string
+          status: string
+        }
+        Update: {
+          admin_notes?: string | null
+          event_id?: number
+          id?: number
+          report_date?: string
+          report_reason?: string
+          reported_id?: string
+          reporter_id?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Reports_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "Events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Reports_reported_id_fkey"
+            columns: ["reported_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Reports_reporter_id_fkey"
+            columns: ["reporter_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      security_logs: {
+        Row: {
+          action: string
+          admin: string
+          created_at: string | null
+          date: string
+          id: string
+          ip: string
+          status: string
+          time: string
+          type: string
+        }
+        Insert: {
+          action: string
+          admin: string
+          created_at?: string | null
+          date: string
+          id?: string
+          ip: string
+          status: string
+          time: string
+          type: string
+        }
+        Update: {
+          action?: string
+          admin?: string
+          created_at?: string | null
+          date?: string
+          id?: string
+          ip?: string
+          status?: string
+          time?: string
+          type?: string
+        }
+        Relationships: []
+      }
+      Sports: {
+        Row: {
+          description: string
+          icon: string
+          id: number
+          name: string
+        }
+        Insert: {
+          description: string
+          icon: string
+          id?: number
+          name: string
+        }
+        Update: {
+          description?: string
+          icon?: string
+          id?: number
+          name?: string
+        }
+        Relationships: []
+      }
+      user_favorite_sports: {
+        Row: {
+          added_at: string
+          sport_id: number
+          user_id: string
+        }
+        Insert: {
+          added_at?: string
+          sport_id: number
+          user_id: string
+        }
+        Update: {
+          added_at?: string
+          sport_id?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_favorite_sports_sport_id_fkey"
+            columns: ["sport_id"]
+            isOneToOne: false
+            referencedRelation: "Sports"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_favorite_sports_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      User_Ratings: {
+        Row: {
+          created_at: string
+          id: number
+          rated_user_id: string
+          rating_user_id: string
+          rating_value: number
+          review_text: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          rated_user_id: string
+          rating_user_id: string
+          rating_value: number
+          review_text: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          rated_user_id?: string
+          rating_user_id?: string
+          rating_value?: number
+          review_text?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "User_Ratings_rated_user_id_fkey"
+            columns: ["rated_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "User_Ratings_rating_user_id_fkey"
+            columns: ["rating_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      User_Sports: {
+        Row: {
+          skill_level: string
+          sport_id: number
+          user_id: string
+        }
+        Insert: {
+          skill_level: string
+          sport_id: number
+          user_id: string
+        }
+        Update: {
+          skill_level?: string
+          sport_id?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "User_Sports_sport_id_fkey"
+            columns: ["sport_id"]
+            isOneToOne: false
+            referencedRelation: "Sports"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "User_Sports_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      User_Warnings: {
+        Row: {
+          admin_id: string | null
+          id: string
+          is_read: boolean | null
+          message: string
+          sent_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          admin_id?: string | null
+          id?: string
+          is_read?: boolean | null
+          message: string
+          sent_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          admin_id?: string | null
+          id?: string
+          is_read?: boolean | null
+          message?: string
+          sent_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "User_Warnings_admin_id_fkey"
+            columns: ["admin_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "User_Warnings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          address: string | null
+          age: number | null
+          bio: string | null
+          created_at: string
+          default_location_latitude: number
+          default_location_longitude: number
+          email: string
+          first_name: string
+          gender: string | null
+          id: string
+          is_watched: boolean
+          last_name: string
+          phone: string
+          profile_picture: string
+          role: string
+          status: string
+          updated_at: string
+          username: string
+          watched_since: string | null
+        }
+        Insert: {
+          address?: string | null
+          age?: number | null
+          bio?: string | null
+          created_at?: string
+          default_location_latitude: number
+          default_location_longitude: number
+          email: string
+          first_name: string
+          gender?: string | null
+          id: string
+          is_watched?: boolean
+          last_name: string
+          phone: string
+          profile_picture: string
+          role?: string
+          status?: string
+          updated_at: string
+          username: string
+          watched_since?: string | null
+        }
+        Update: {
+          address?: string | null
+          age?: number | null
+          bio?: string | null
+          created_at?: string
+          default_location_latitude?: number
+          default_location_longitude?: number
+          email?: string
+          first_name?: string
+          gender?: string | null
+          id?: string
+          is_watched?: boolean
+          last_name?: string
+          phone?: string
+          profile_picture?: string
+          role?: string
+          status?: string
+          updated_at?: string
+          username?: string
+          watched_since?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      get_category_participant_counts: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          category_name: string
+          participant_count: number
+        }[]
+      }
+      get_weekly_stats: {
+        Args: {
+          start_date: string // timestamp with time zone
+          end_date: string // timestamp with time zone
+        }
+        Returns: {
+            stat_date: string // date
+            event_count: number // bigint
+            participant_count: number // bigint
+        }[]
+      }
+      get_monthly_event_stats: {
+        Args: Record<PropertyKey, never> // No arguments for this function
+        Returns: {
+          event_month: string // text (YYYY-MM)
+          status_counts: Json // jsonb (e.g., {"approved": 5, "pending": 2})
+        }[]
+      }
+      get_user_growth_by_category: {
+        Args: {
+          period_days: number // integer
+        }
+        Returns: {
+          category_name: string // text
+          total_users: number   // bigint (maps to number in TS)
+          change: number        // bigint (maps to number in TS)
+        }[]
+      }
+      register: {
+        Args: { name: string; email: string; password: string }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DefaultSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const


### PR DESCRIPTION
 haftalık ve aylık etkinlik istatistiklerini almak için API endpoint'leri eklendi. /api/stats/weekly endpoint'i, belirtilen haftadaki (varsayılan olarak son 7 gün) etkinlikleri getirecek ve her bir etkinliğin o haftanın her bir günündeki gerçek durumunu (pending, active, completed, rejected) hesaplayacak şekilde geliştirildi. Bu hesaplama, etkinliğin tüm yaşam döngüsünü (created_at, start_time, end_time, approved_at, rejected_at zaman damgalarını kullanarak) dikkate alacak şekilde yapıldı. Sonuç olarak, her bir günü temsil eden ve o güne ait durum sayılarını içeren düz bir dizi döndürülmesi sağlandı. Bu detaylı takibi sağlamak için Events tablosuna approved_at ve rejected_at sütunları eklendi ve etkinlik onaylama/reddetme (eventService.ts içindeki updateEventStatus) mantığı bu yeni sütunları dolduracak şekilde güncellendi. /api/stats/monthly endpoint'i ise mevcut get_monthly_event_stats Supabase RPC fonksiyonunu kullanarak, belirli bir aydaki etkinlikleri son durumlarına göre gruplayıp sayacak şekilde ayarlandı. Bu süreçte istatistik mantığı StatsController ve StatsService dosyalarına taşınarak refactor edildi ve çeşitli TypeScript hataları giderildi. Bu endpoint'ler ile etkinlik aktivitesi ve durum dağılımı hakkında zaman içinde değerli bilgiler sunulması sağlandı.