### PR TITLE
feat: add news creation endpoint for admin and fix api/sports endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/cron": "^2.0.1",
         "@types/multer": "^1.4.12",
         "@types/nodemailer": "^6.4.17",
+        "@types/uuid": "^10.0.0",
         "axios": "^1.8.4",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
@@ -32,6 +33,7 @@
         "socket.io": "^4.8.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
+        "uuid": "^11.1.0",
         "winston": "^3.17.0",
         "zod": "^3.24.2"
       },
@@ -2360,6 +2362,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/winston": {
@@ -8434,6 +8442,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/cron": "^2.0.1",
     "@types/multer": "^1.4.12",
     "@types/nodemailer": "^6.4.17",
+    "@types/uuid": "^10.0.0",
     "axios": "^1.8.4",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
@@ -43,6 +44,7 @@
     "socket.io": "^4.8.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "zod": "^3.24.2"
   },

--- a/src/controllers/NewsController.ts
+++ b/src/controllers/NewsController.ts
@@ -1,0 +1,61 @@
+import { Request, Response, NextFunction } from 'express';
+import { NewsService } from '../services/NewsService';
+import logger from '../utils/logger';
+
+export const NewsController = {
+  async createNews(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      // Metin alanlarını req.body'den al
+      const { title, content, sport_id: sportIdStr } = req.body;
+      // Görsel dosyasını req.file'dan al (multer tarafından eklenir)
+      const file = req.file;
+      // Admin kullanıcısının ID'sini req.userProfile'dan al (auth middleware tarafından eklenir)
+      const creatorId = req.userProfile?.id;
+
+      // Zorunlu alan kontrolü (başlık, içerik, sport_id)
+      if (!title || !content || !sportIdStr) {
+        res.status(400).json({ status: 'error', message: `Başlık, içerik ve spor kategorisi ID'si alanları zorunludur.` });
+        return;
+      }
+
+      // sport_id'yi sayıya çevir ve doğrula
+      const sport_id = parseInt(sportIdStr, 10);
+      if (isNaN(sport_id)) {
+          res.status(400).json({ status: 'error', message: `Spor kategorisi ID'si geçerli bir sayı olmalıdır.` });
+          return;
+      }
+
+      // creatorId kontrolü
+      if (!creatorId) {
+         logger.error('NewsController.createNews: Creator ID bulunamadı!', { userProfile: req.userProfile });
+         res.status(401).json({ status: 'error', message: 'Kullanıcı kimliği doğrulanamadı.' });
+         return;
+      }
+
+      logger.info('NewsController: Haber oluşturma isteği alındı', { title, creatorId, sport_id, hasFile: !!file });
+
+      // Servis katmanını çağır (güncellenmiş input ile)
+      const newNews = await NewsService.createNews({
+        title,
+        content,
+        creatorId,
+        sport_id, // Doğrulanmış sayısal ID
+        file
+      });
+
+      // Başarılı yanıt
+      res.status(201).json({
+        status: 'success',
+        message: 'Haber başarıyla oluşturuldu.',
+        data: newNews
+      });
+
+    } catch (error) {
+      // Hata yönetimi
+      logger.error('NewsController.createNews - Hata:', error);
+      next(error);
+    }
+  }
+
+  // Diğer NewsController fonksiyonları (getNews, deleteNews vb.) buraya eklenebilir
+}; 

--- a/src/controllers/SportsController.ts
+++ b/src/controllers/SportsController.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express';
+import { SportsService } from '../services/SportsService';
+import logger from '../utils/logger';
+
+export const SportsController = {
+  async getAllSports(req: Request, res: Response, next: NextFunction): Promise<void> {
+    logger.info('SportsController: Tüm spor kategorileri isteği alındı.');
+    try {
+      const sports = await SportsService.getAllSports();
+
+      res.status(200).json({
+        status: 'success',
+        message: 'Spor kategorileri başarıyla getirildi.',
+        data: sports
+      });
+
+    } catch (error) {
+      logger.error('SportsController.getAllSports - Hata:', error);
+      next(error); // Hata yönetimi için merkezi yere gönder
+    }
+  }
+}; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import reportRoutes from './routes/reportRoutes';
 import profileRoutes from './routes/profileRoutes';
 import statsRoutes from './routes/statsRoutes';
 import statisticsRoutes from './routes/statisticsRoutes';
+import newsRoutes from './routes/newsRoutes';
 import { errorHandler } from './middleware/errorHandler';
 import logRequest from './middleware/loggerMiddleware';
 import { setupSwagger } from './middleware/swaggerMiddleware';
@@ -58,7 +59,7 @@ app.use('/api/sports', sportsRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/stats', statsRoutes);
-app.use('/api/statistics', statisticsRoutes);
+app.use('/api/news', newsRoutes);
 
 // Error handling middleware
 app.use(errorHandler);

--- a/src/middleware/adminCheckMiddleware.ts
+++ b/src/middleware/adminCheckMiddleware.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import logger from '../utils/logger'; // Loglama için logger'ı import edelim
+
+export const isAdmin = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    // userProfile nesnesinin ve role özelliğinin varlığını kontrol et
+    // Rolün 'ADMIN' olup olmadığını kontrol et (Büyük/küçük harf duyarlı olabilir, veritabanındaki değere göre ayarlayın)
+    if (req.userProfile && req.userProfile.role === 'ADMIN') {
+      // Kullanıcı admin ise bir sonraki adıma geç
+      next();
+    } else {
+      // Kullanıcı admin değilse veya userProfile yoksa yetkisiz hatası döndür
+      logger.warn(`Admin yetki reddedildi: Kullanıcı ID ${req.userProfile?.id || 'bilinmiyor'}, Rol: ${req.userProfile?.role || 'yok'}`);
+      res.status(403).json({
+        status: 'error',
+        message: 'Bu işlemi gerçekleştirmek için admin yetkisine sahip olmalısınız.'
+      });
+    }
+  } catch (error) {
+    // Beklenmedik bir hata olursa logla ve sunucu hatası döndür
+    logger.error('Admin kontrol middleware hatası:', error);
+    res.status(500).json({
+      status: 'error',
+      message: 'Yetki kontrolü sırasında bir sunucu hatası oluştu.'
+    });
+  }
+}; 

--- a/src/routes/newsRoutes.ts
+++ b/src/routes/newsRoutes.ts
@@ -1,0 +1,92 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { NewsController } from '../controllers/NewsController';
+import { protect } from '../middleware/authMiddleware';
+import { isAdmin } from '../middleware/adminCheckMiddleware';
+import logger from '../utils/logger';
+
+const router = Router();
+
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) {
+      cb(null, true);
+    } else {
+      logger.warn(`Geçersiz dosya türü yüklendi: ${file.mimetype}, fieldname=${file.fieldname}`);
+      cb(new Error('Sadece resim dosyaları yüklenebilir!'));
+    }
+  }
+});
+
+/**
+ * @swagger
+ * /api/news:
+ *   post:
+ *     summary: Create a new news item or announcement (Admin Only)
+ *     tags: [News]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *               - content
+ *               - sport_id
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 description: The title of the news item.
+ *                 example: "Yeni Turnuva Duyurusu"
+ *               content:
+ *                 type: string
+ *                 description: The main content/body of the news item.
+ *                 example: "Detaylar çok yakında..."
+ *               sport_id:
+ *                 type: integer
+ *                 description: The ID of the sport category this news belongs to.
+ *                 example: 4
+ *               image:
+ *                 type: string
+ *                 format: binary
+ *                 description: Optional image file for the news item.
+ *     responses:
+ *       '201':
+ *         description: News item created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Haber başarıyla oluşturuldu.
+ *                 data:
+ *                   $ref: '#/components/schemas/News' # Assuming you have a News schema in models
+ *       '400':
+ *         description: Bad Request - Missing required fields or invalid input.
+ *       '401':
+ *         description: Unauthorized - User not logged in.
+ *       '403':
+ *         description: Forbidden - User is not an admin.
+ *       '500':
+ *         description: Internal Server Error.
+ */
+router.post(
+  '/',
+  protect,
+  isAdmin,
+  upload.single('image'),
+  NewsController.createNews
+);
+
+export default router; 

--- a/src/routes/sportsRoutes.ts
+++ b/src/routes/sportsRoutes.ts
@@ -1,7 +1,9 @@
-import express from 'express';
-import * as SportController from '../controllers/SportController';
+import { Router } from 'express';
+import { SportsController } from '../controllers/SportsController';
+// Gerekirse authentication/authorization middleware eklenebilir
+// import { protect, authorize } from '../middleware/authMiddleware';
 
-const router = express.Router();
+const router = Router();
 
 /**
  * @swagger
@@ -41,6 +43,6 @@ const router = express.Router();
  *       500:
  *         description: Sunucu hatası
  */
-router.get('/', SportController.getAllSports);
+router.get('/', SportsController.getAllSports);
 
 export default router; 

--- a/src/services/NewsService.ts
+++ b/src/services/NewsService.ts
@@ -1,0 +1,124 @@
+import { v4 as uuidv4 } from 'uuid'; // Benzersiz dosya adları için
+import { supabaseAdmin } from '../config/supabase'; // Admin client'ı kullanalım (storage/db için)
+import logger from '../utils/logger';
+import { Database } from '../types/supabase'; // Supabase tipleri
+
+// Supabase Storage bucket adını 'content' olarak değiştir
+const NEWS_IMAGE_BUCKET = 'sportlink-files'; 
+// Gerekirse kullanılacak sabitler
+// const NEWS_TYPE_ANNOUNCEMENT = 'announcement';
+// const DEFAULT_NEWS_STATUS = 'published';
+
+type NewsInput = {
+  title: string;
+  content: string;
+  creatorId: string; // Bu hala gerekli olabilir, kimin oluşturduğunu bilmek için
+  sport_id: number; // Zorunlu hale getirildi
+  // sendNotification kaldırıldı
+  file?: Express.Multer.File; // Multer'dan gelen dosya (opsiyonel)
+};
+
+// Tip tanımı (Supabase tiplerinden türetilebilir ama şimdilik basit tutalım)
+type News = Database['public']['Tables']['News']['Row'];
+
+
+export const NewsService = {
+  async createNews(input: NewsInput): Promise<News> {
+    // sendNotification kaldırıldı
+    const { title, content, creatorId, sport_id, file } = input;
+    let imageUrl: string | null = null;
+
+    logger.info(`Haber oluşturma işlemi başlatıldı: title=${title}, creatorId=${creatorId}, sportId=${sport_id}, file=${!!file}`);
+
+    try {
+      // 1. Görsel Yükleme (varsa)
+      if (file) {
+        const fileExtension = file.originalname.split('.').pop();
+        const uniqueFileName = `${uuidv4()}.${fileExtension}`;
+        // Dosya yolunu 'content' bucket'ı içindeki 'news' klasörüne ayarla
+        const filePath = `news/${uniqueFileName}`; 
+
+        logger.info(`Görsel yükleniyor: bucket=${NEWS_IMAGE_BUCKET}, path=${filePath}`);
+
+        const { data: uploadData, error: uploadError } = await supabaseAdmin.storage
+          .from(NEWS_IMAGE_BUCKET) // Correct bucket name used here
+          .upload(filePath, file.buffer, { // Correct file path used here
+            contentType: file.mimetype,
+          });
+
+        if (uploadError) {
+          logger.error(`Supabase Storage yükleme hatası: ${uploadError.message}`, uploadError);
+          throw new Error('Görsel yüklenirken bir hata oluştu.');
+        }
+
+        // Yüklenen dosyanın public URL'ini al
+        const { data: urlData } = supabaseAdmin.storage
+          .from(NEWS_IMAGE_BUCKET)
+          .getPublicUrl(filePath);
+
+        imageUrl = urlData?.publicUrl || null;
+        logger.info(`Görsel başarıyla yüklendi: url=${imageUrl}`);
+      }
+
+      // 2. Veritabanına Kaydetme
+      const newsDataToInsert = {
+        title,
+        content,
+        image_url: imageUrl,
+        sport_id, // Girdiden gelen sport_id kullanılıyor
+        // Creator ID, type, status gibi sütunlar News tablosunda yoksa kaldırılmalı
+        // Eğer varsa ve gerekli ise creatorId buraya eklenebilir: creator_id: creatorId,
+        published_date: new Date().toISOString(), // Use ISO string for timestamp
+        created_at: new Date().toISOString(), // Use ISO string
+        updated_at: new Date().toISOString(), // Use ISO string
+        source_url: '' as string | null, // Provide default or null
+      };
+
+      logger.info('Haber veritabanına ekleniyor:', newsDataToInsert);
+
+      const { data: newNews, error: insertError } = await supabaseAdmin
+        .from('News') // Tablo adının 'News' olduğundan emin ol
+        .insert([newsDataToInsert])
+        .select()
+        .single();
+
+      if (insertError) {
+        logger.error(`Supabase veritabanı ekleme hatası: ${insertError.message}`, insertError);
+        // İlişkisel hatalar (örn: sport_id yok) için daha spesifik kontrol
+        if (insertError.code === '23503') {
+           // Daha açıklayıcı bir mesaj
+           if (insertError.message.includes('News_sport_id_fkey')) {
+             throw new Error(`Geçersiz Spor Kategorisi ID'si: ${sport_id}. Bu ID'ye sahip bir spor kategorisi bulunamadı.`);
+           }
+           // Diğer olası foreign key hataları için genel mesaj
+           throw new Error('İlişkili veri bulunamadı (örn. geçersiz ID).');
+        }
+        // Diğer veritabanı hataları
+        throw new Error('Haber veritabanına kaydedilirken bir hata oluştu.');
+      }
+
+      if (!newNews) {
+          logger.error('Haber oluşturuldu ancak veri döndürülemedi.');
+          throw new Error('Haber oluşturuldu ancak sonuç alınamadı.');
+      }
+
+      logger.info(`Haber başarıyla oluşturuldu: id=${newNews.id}`);
+
+      // 3. Bildirim Gönderme kısmı tamamen kaldırıldı
+
+      return newNews as News;
+
+    } catch (error) {
+      logger.error(`Haber oluşturma servisinde hata: ${error instanceof Error ? error.message : 'Bilinmeyen hata'}`, error);
+      // Hataları tekrar fırlat ki controller yakalayabilsin
+      throw error;
+    }
+  }
+  // Diğer NewsService fonksiyonları (getNews, updateNews, deleteNews vb.) buraya eklenebilir
+};
+
+// Eğer NewsService'i class olarak tanımlamak istersen:
+// export class NewsService {
+//   async createNews(...) { ... }
+// }
+// export default new NewsService(); 

--- a/src/services/SportsService.ts
+++ b/src/services/SportsService.ts
@@ -1,0 +1,28 @@
+import { supabaseAdmin } from '../config/supabase';
+import logger from '../utils/logger';
+import { Database } from '../types/supabase';
+
+type Sport = Database['public']['Tables']['Sports']['Row'];
+
+export const SportsService = {
+  async getAllSports(): Promise<Sport[]> {
+    logger.info('SportsService: Tüm spor kategorileri getiriliyor...');
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('Sports')
+        .select('id, name, description, icon'); // Gerekli alanları seç
+
+      if (error) {
+        logger.error(`Supabase 'Sports' tablosu okuma hatası:`, error);
+        throw new Error('Spor kategorileri getirilirken bir veritabanı hatası oluştu.');
+      }
+
+      logger.info(`SportsService: ${data?.length || 0} adet spor kategorisi bulundu.`);
+      return data || []; // Veri null ise boş dizi döndür
+
+    } catch (error) {
+      logger.error(`Spor kategorileri getirme servisinde hata: ${error instanceof Error ? error.message : 'Bilinmeyen hata'}`, error);
+      throw error;
+    }
+  }
+}; 


### PR DESCRIPTION
 Admin İçin Haber Ekleme Özelliği (POST /api/news):
Admin yetkisine sahip kullanıcıların yeni haber veya duyuru oluşturabilmesi için POST /api/news endpoint'i eklendi.
Endpoint, multipart/form-data formatında istek kabul eder ve şu alanları alır:
title (string, zorunlu): Haber başlığı.
content (string, zorunlu): Haber içeriği.
sport_id (integer, zorunlu): Haberin ait olduğu spor kategorisinin ID'si.
image (file, opsiyonel): Haber için görsel dosyası.
Görsel yükleme multer ile yönetilir ve Supabase Storage'a (sportlink-files bucket'ı) kaydedilir.
Veritabanı işlemleri NewsService üzerinden yapılır. sendNotification işlevi kaldırıldı.
sport_id alanı zorunlu hale getirildi ve ilgili hata yönetimi iyileştirildi.
Swagger dokümantasyonu bu değişiklikleri yansıtacak şekilde güncellendi.
. Spor Kategorilerini Listeleme Endpoint'i (GET /api/sports):
Önyüzün, haber ekleme formunda kullanabilmesi amacıyla, veritabanındaki tüm spor kategorilerini (id, name, description, icon) listeleyen GET /api/sports endpoint'i eklendi/düzeltildi.
Bu işlem için SportsService ve SportsController oluşturuldu.
Swagger dokümantasyonu güncellendi.